### PR TITLE
Update createBrowserHistory

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _createBrowserHistory = require('history/createBrowserHistory');
+var _createBrowserHistory = require("history").createBrowserHistory;
 
 var _createBrowserHistory2 = _interopRequireDefault(_createBrowserHistory);
 


### PR DESCRIPTION
Gatsby is giving the warning: 

Warning: Please use `require("history").createBrowserHistory` instead of `require("history/createBrowserHistory")`. Support for the latter will be removed in the next major release.