### PR TITLE
Fixed warning message about require history

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _createBrowserHistory = require('history/createBrowserHistory');
+var _createBrowserHistory = require("history").createBrowserHistory;
 
 var _createBrowserHistory2 = _interopRequireDefault(_createBrowserHistory);
 


### PR DESCRIPTION
For reference this is the exact message

Warning: Please use `require("history").createBrowserHistory` instead of `require("history/createBrowserHistory")`. Support for the latter will be removed in the next major release.